### PR TITLE
Configure openvpn for flight terminals

### DIFF
--- a/apt-packages
+++ b/apt-packages
@@ -1,0 +1,1 @@
+openvpn


### PR DESCRIPTION
My initial attempts at configuring openvpn inside a container by using a `post-deploy` script defined in `app.json` ran into a few issues:

 1. The device `/dev/net/tun` does not exist in the image and without it, the openvpn command will not function correctly.
 2. The script runs as the app user and is not able to create the node `/dev/net/tun`.
 3. Changes to `/dev/net/tun` are not persisted to the container.
 4. Containers, by default, cannot configure their own network.

Manual experimentation showed that when a container is running it is possible to use `docker` commands to gain a root shell.  From where we can create the tun/tap device, copy configuration files into place and restart the openvpn service.

A complete solution requires a script to do the above which is executed each time the app is deployed or rebuilt, or its container restarted or scaled.  Dokku provides hooks that its plugins can use to do just this.

A plugin implementing the functionality we want can be found at https://github.com/alces-software/dokku-openvpn-client.  It is live and functioning on apps.alces-flight.com.  It contains a README detailing the steps required to add openvpn client support to any other app.  I'll repeat them here anyway:

 1. Create openvpn configuration files, auth files and certificates.
 2. Store them on the apps instance at `/home/dokku/${APP}/DOKKU_FILES/` each with a prefix of `openvpn-client-`.
 3. Add support for configuring a containers network: `dokku docker-options:add ${APP} run --cap-add=NET_ADMIN`.
 4. Configure the app so that the openvpn-client plugin does its thing: `dokku config:set --no-restart ${APP} CONFIGURE_OPENVPN_CLIENT=true`
 5. Add an `apt-packages` file to the app's repo containing the line `openvpn`.
