### PR TITLE
Add extra basic installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 Flight Terminal Service is a service provided by Alces Flight to support
 embedding a terminal in a browser session.
 
+## Prerequisites
+
+* Yarn
+* Node.js v8.12
+
+## Installation
+
+* Clone this repo using `git clone https://github.com/alces-software/flight-terminal-service.git`
 
 ## Quick start
 


### PR DESCRIPTION
To keep installation instructions for this service outside of the `Overware` documentation I have extracted the difference here. This only adds a very basic instruction and prerequisites but it means in the future if anything changes we only need to change the documentation here.

Please let me know if I have missed any important step in the installation process or if something is incorrect.